### PR TITLE
SIM-7 filter category, improve logic for item, quick fisnish item

### DIFF
--- a/app/Controllers/CategoryController.php
+++ b/app/Controllers/CategoryController.php
@@ -66,6 +66,11 @@ class CategoryController extends BaseController
     private function getMethodInfoCategory($id, RouteCollection $routes) {
         $allItems = $this->itemService->getByCategory($id);
         $category = $this->categoryService->getById($id);
+        $allCategories = $this->categoryService->getAll();
+        $categories = array();
+        foreach ($allCategories as $category) {
+            $categories[$category->getId()] = $category->getContent();                                 
+        }
         require_once $this->loadView('infoCategory.php');
     }
 }

--- a/app/Controllers/HomeController.php
+++ b/app/Controllers/HomeController.php
@@ -9,8 +9,9 @@ use Symfony\Component\Routing\RouteCollection;
 
 class HomeController extends BaseController
 {
-    const ITEM_MODEL = 0;
-    const CATEGORY_MODEL = 1;
+    const DELETE_ITEM = 0;
+    const DELETE_CATEGORY = 1;
+    const FINISH = 2;
     private $itemService; 
     private $categoryService;
 
@@ -37,12 +38,15 @@ class HomeController extends BaseController
             $id = $_POST['id'];
             
             switch ($model) {
-                case self::ITEM_MODEL:
-                  $this->deleteItem($id);
-                  break;
-                case self::CATEGORY_MODEL:
-                  $this->deleteCategory($id);
-                  break;
+                case self::DELETE_ITEM:
+                    $this->deleteItem($id);
+                    break;
+                case self::DELETE_CATEGORY:
+                    $this->deleteCategory($id);
+                    break;
+                case self::FINISH:
+                    $this->finishItem($id);
+                    break;
             }
         }
         $this->getMethodHome($routes);
@@ -51,7 +55,11 @@ class HomeController extends BaseController
     private function getMethodHome(RouteCollection $routes){
         $todayItems = $this->itemService->getTodayItems();
         $allItems = $this->itemService->getAll();
-        $allCategory = $this->categoryService->getAll();
+        $allCategories = $this->categoryService->getAll();
+        $categories = array();
+        foreach ($allCategories as $category) {
+            $categories[$category->getId()] = $category->getContent();                                 
+        }
         require_once $this->loadView('home.php');
     }
 
@@ -61,5 +69,9 @@ class HomeController extends BaseController
 
     private function deleteCategory($id){
         $this->categoryService->delete(intval($id));
+    }
+
+    private function finishItem($id){
+        $this->itemService->finishItem($id);
     }
 }

--- a/app/Controllers/ItemController.php
+++ b/app/Controllers/ItemController.php
@@ -1,5 +1,6 @@
 <?php 
 namespace App\Controllers;
+use App\Models\Item;
 use App\Services\CategoryService;
 use App\Services\ItemService;
 use Symfony\Component\Routing\RouteCollection;
@@ -28,6 +29,11 @@ class ItemController extends BaseController
 
     private function getMethodAddItem($id, RouteCollection $routes){
         $allCategories = $this->categoryService->getAll();
+        $categories = array();
+        foreach ($allCategories as $category) {
+            $categories[$category->getId()] = $category->getContent();                                 
+        }
+        $parentItem = $id === null ? new Item() : $this->itemService->getById($id);
         require_once $this->loadView('addItem.php');
     }
 
@@ -86,6 +92,10 @@ class ItemController extends BaseController
         $subItems = $this->itemService->getSubItems($id);
         $parentItems = [$this->itemService->getById($mainItem->getParentId())];
         $allCategories = $this->categoryService->getAll();
+        $categories = array();
+        foreach ($allCategories as $category) {
+            $categories[$category->getId()] = $category->getContent();                                 
+        }
         require_once $this->loadView('infoItem.php');
     }
 }

--- a/views/addItem.php
+++ b/views/addItem.php
@@ -31,8 +31,15 @@
         <select name="category" id="category" required>
                 <?php
                         $html = '';
-                        foreach ($allCategories as $item) {
-                            $html .= '<option value=' . $item->getId() . '>' . $item->getContent() . '</option>';
+                        foreach ($allCategories as $category) {
+                            if($id !== 'null') {
+                                $html .= '<option value="' . htmlspecialchars($parentItem->getCategoryId()) . ' selected">' . htmlspecialchars($categories[$parentItem->getCategoryId()]) . '</option>';
+                                break;
+                            }
+                            $categoryId = $category->getId();
+                            $categoryContent = $category->getContent();
+                            $selected = ($categoryId === $parentItem->getCategoryId()) ? 'selected' : '';
+                            $html .= '<option value="' . htmlspecialchars($categoryId) . '" ' . $selected . '>' . htmlspecialchars($categoryContent) . '</option>';
                         }
                     echo $html;
                 ?>
@@ -54,5 +61,18 @@
         <input class="btn" type="submit" value="Add">
     </form>
     </div>
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            var startDateInput = document.getElementById("finishedTime");
+
+            var today = new Date().toISOString().split('T')[0];
+            var max = <?php echo '"' . $parentItem->getFinishTime() . '";'?>
+
+            startDateInput.setAttribute("min", today);
+            if(max !== 'null') {
+                startDateInput.setAttribute("max", max);
+            }
+        })
+</script>
 </body>
 </html>

--- a/views/css/additem.css
+++ b/views/css/additem.css
@@ -49,3 +49,16 @@ textarea {
     width: 450px;
     height: 150px;
 }
+
+.finish-btn {
+    padding: 4px 8px;
+    background-color: #17c312;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+  }
+  
+  .finish-btn:hover {
+    background-color: #058505;
+  }

--- a/views/css/infoItem.css
+++ b/views/css/infoItem.css
@@ -148,3 +148,16 @@ body {
   .edit-btn:hover {
     background-color: #09489b;
   }
+
+  .finish-btn {
+    padding: 4px 8px;
+    background-color: #17c312;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+  }
+  
+  .finish-btn:hover {
+    background-color: #058505;
+  }

--- a/views/css/styles.css
+++ b/views/css/styles.css
@@ -114,3 +114,16 @@ h1 {
 .edit-btn:hover {
   background-color: #09489b;
 }
+
+.finish-btn {
+  padding: 4px 8px;
+  background-color: #17c312;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.finish-btn:hover {
+  background-color: #058505;
+}

--- a/views/home.php
+++ b/views/home.php
@@ -34,12 +34,23 @@
                         <th>Update Date</th>
                         <th>Finish Date</th>
                         <th>Status : 
-                            <select onchange="filterTableByStatus('table1')">
+                            <select name='status' onchange="filterTable('table1')">
                                 <option value='ALL'>ALL</option>
                                 <option value='TODO'>TODO</option>
                                 <option value='INPROGRESS'>INPROGRESS</option>
                                 <option value='COMPLETE'>COMPLETE</option>
                                 <option value='POSTPONE'>POSTPONE</option>
+                            </select>
+                        </th>
+                        <th>Category : 
+                            <select name='category' onchange="filterTable('table1')">
+                                <option value='ALL'>ALL</option>
+                                <?php
+                                    foreach ($allCategories as $category) {
+                                        $categoryContent = $category->getContent();
+                                        echo '<option value="' . htmlspecialchars($categoryContent) . '" ' . '>' . htmlspecialchars($categoryContent) . '</option>';
+                                    }
+                                ?>
                             </select>
                         </th>
                         <th>Action</th>
@@ -52,9 +63,11 @@
                                 $html .= '<td>' . $item->getUpdateTime() . '</td>';
                                 $html .= '<td>' . $item->getFinishTime() . '</td>';
                                 $html .= '<td>' . STATUS[$item->getStatus()] . '</td>';
+                                $html .= '<td>' . $categories[$item->getCategoryId()] . '</td>';
                                 $html .= '<td>';
                                 $html .= '<a class="delete-btn" onclick="postForm(0, ' . $item->getId() . ')">Delete</a>';
                                 $html .= '<a class="edit-btn" href="' . str_replace('{id}', $item->getId(), $routes->get('loadInfoItem')->getPath()) . '">Edit</a>';
+                                $html .= '<a class="finish-btn" onclick="postForm(2, ' . $item->getId() . ')">Finish</a>';
                                 $html .= '</td>';
                                 $html .= '</tr>';
                             }
@@ -67,17 +80,28 @@
         <div id="tab2" class="tabcontent">
             <div class="roll-table">
                 <table class="task-table" id="table2">
-                    <tr>
+                <tr>
                         <th>Title</th>
                         <th>Update Date</th>
                         <th>Finish Date</th>
-                        <th>Status :
-                            <select onchange="filterTableByStatus('table2')">
+                        <th>Status : 
+                            <select name="status" onchange="filterTable('table2')">
                                 <option value='ALL'>ALL</option>
                                 <option value='TODO'>TODO</option>
                                 <option value='INPROGRESS'>INPROGRESS</option>
                                 <option value='COMPLETE'>COMPLETE</option>
                                 <option value='POSTPONE'>POSTPONE</option>
+                            </select>
+                        </th>
+                        <th>Category : 
+                            <select name="category" onchange="filterTable('table2')">
+                                <option value='ALL'>ALL</option>
+                                <?php
+                                    foreach ($allCategories as $category) {
+                                        $categoryContent = $category->getContent();
+                                        echo '<option value="' . htmlspecialchars($categoryContent) . '" ' . '>' . htmlspecialchars($categoryContent) . '</option>';
+                                    }
+                                ?>
                             </select>
                         </th>
                         <th>Action</th>
@@ -90,9 +114,11 @@
                                 $html .= '<td>' . $item->getUpdateTime() . '</td>';
                                 $html .= '<td>' . $item->getFinishTime() . '</td>';
                                 $html .= '<td>' . STATUS[$item->getStatus()] . '</td>';
+                                $html .= '<td>' . $categories[$item->getCategoryId()] . '</td>';
                                 $html .= '<td>';
                                 $html .= '<a class="delete-btn" onclick="postForm(0, ' . $item->getId() . ')">Delete</a>';
                                 $html .= '<a class="edit-btn" href="' . str_replace('{id}', $item->getId(), $routes->get('loadInfoItem')->getPath()) . '">Edit</a>';
+                                $html .= '<a class="finish-btn" onclick="postForm(2, ' . $item->getId() . ')">Finish</a>';
                                 $html .= '</td>';
                                 $html .= '</tr>';
                             }
@@ -117,7 +143,7 @@
                     </tr>
                     <?php
                         $html = '';
-                        foreach ($allCategory as $item) {
+                        foreach ($allCategories as $item) {
                             $html .= '<tr>';
                             $html .= '<td>' . $item->getContent() . '</td>';
                             $html .= '<td>' . $item->getUpdateTime() . '</td>';
@@ -149,35 +175,51 @@
             evt.currentTarget.className += " active";
         }
 
-        function filterTableByStatus(tableId) {
-            var statusFilter = document.querySelector('#' + tableId + ' select');
-            
+        function filterTable(tableId) {
+            var statusFilter = document.querySelector('#' + tableId + ' select[name="status"]');
             var selectedStatus = statusFilter.value;
-            
+
+            var categoryFilter = document.querySelector('#' + tableId + ' select[name="category"]');
+            var selectedCategory = categoryFilter.value;
+
             var rows = document.querySelectorAll('#' + tableId + ' tr');
             
-            if (selectedStatus === 'ALL') {
-                for (var i = 0; i < rows.length; i++) {
+            for (var i = 1; i < rows.length; i++) {
+                var rowStatus = rows[i].querySelector('td:nth-child(4)').innerHTML;
+                var rowCategory = rows[i].querySelector('td:nth-child(5)').innerHTML;
+
+                if ((rowStatus === selectedStatus || selectedStatus === 'ALL') && (rowCategory === selectedCategory || selectedCategory === 'ALL')) {
                     rows[i].style.display = 'table-row';
-                }
-            } else {
-                for (var i = 1; i < rows.length; i++) {
-                    var rowStatus = rows[i].querySelector('td:nth-child(4)').innerHTML;
-                    
-                    if (rowStatus !== selectedStatus) {
-                        rows[i].style.display = 'none';
-                    } else {
-                        rows[i].style.display = 'table-row';
-                    }
+                } else {
+                    rows[i].style.display = 'none';
                 }
             }
+            
         }
+        
 
         function postForm(model, id){
-            document.getElementById('id').value = id;
-            document.getElementById('model').value = model;
-            form = document.getElementById("postForm");
-            form.submit();
+
+            var actionText = "";
+            switch(model) {
+                case 0:
+                    actionText = "delete this item ? ";
+                    break;
+                case 1:
+                    actionText = "delete this category ? it also delete all item fllow";
+                    break;
+                case 2:
+                    actionText = "finish this item ? it and all children (if have) will be COMPLETE";
+                    break;
+                }
+            var confirmationMessage = "Are you sure you want to " + actionText;
+
+            if (window.confirm(confirmationMessage)) {
+                document.getElementById('id').value = id;
+                document.getElementById('model').value = model;
+                form = document.getElementById("postForm");
+                form.submit();
+            } 
         }
     </script>
 </body>

--- a/views/infoCategory.php
+++ b/views/infoCategory.php
@@ -34,17 +34,28 @@
         <div id="tab2" class="tabcontent">
             <div class="roll-table">
                 <table class="task-table" id="table2">
-                    <tr>
+                <tr>
                         <th>Title</th>
                         <th>Update Date</th>
                         <th>Finish Date</th>
-                        <th>Status :
-                            <select onchange="filterTableByStatus('table2')">
+                        <th>Status : 
+                            <select name='status' onchange="filterTable('table2')">
                                 <option value='ALL'>ALL</option>
                                 <option value='TODO'>TODO</option>
                                 <option value='INPROGRESS'>INPROGRESS</option>
                                 <option value='COMPLETE'>COMPLETE</option>
                                 <option value='POSTPONE'>POSTPONE</option>
+                            </select>
+                        </th>
+                        <th>Category : 
+                            <select name='category' onchange="filterTable('table2')">
+                                <option value='ALL'>ALL</option>
+                                <?php
+                                    foreach ($allCategories as $category) {
+                                        $categoryContent = $category->getContent();
+                                        echo '<option value="' . htmlspecialchars($categoryContent) . '" ' . '>' . htmlspecialchars($categoryContent) . '</option>';
+                                    }
+                                ?>
                             </select>
                         </th>
                         <th>Action</th>
@@ -57,9 +68,11 @@
                                 $html .= '<td>' . $item->getUpdateTime() . '</td>';
                                 $html .= '<td>' . $item->getFinishTime() . '</td>';
                                 $html .= '<td>' . STATUS[$item->getStatus()] . '</td>';
+                                $html .= '<td>' . $categories[$item->getCategoryId()] . '</td>';
                                 $html .= '<td>';
                                 $html .= '<a class="delete-btn" onclick="postForm(0, ' . $item->getId() . ')">Delete</a>';
                                 $html .= '<a class="edit-btn" href="' . str_replace('{id}', $item->getId(), $routes->get('loadInfoItem')->getPath()) . '">Edit</a>';
+                                $html .= '<a class="finish-btn" onclick="postForm(2, ' . $item->getId() . ')">Finish</a>';
                                 $html .= '</td>';
                                 $html .= '</tr>';
                             }
@@ -89,35 +102,49 @@
             evt.currentTarget.className += " active";
         }
 
-        function filterTableByStatus(tableId) {
-            var statusFilter = document.querySelector('#' + tableId + ' select');
-            
+        function filterTable(tableId) {
+            var statusFilter = document.querySelector('#' + tableId + ' select[name="status"]');
             var selectedStatus = statusFilter.value;
-            
+
+            var categoryFilter = document.querySelector('#' + tableId + ' select[name="category"]');
+            var selectedCategory = categoryFilter.value;
+
             var rows = document.querySelectorAll('#' + tableId + ' tr');
             
-            if (selectedStatus === 'ALL') {
-                for (var i = 0; i < rows.length; i++) {
+            for (var i = 1; i < rows.length; i++) {
+                var rowStatus = rows[i].querySelector('td:nth-child(4)').innerHTML;
+                var rowCategory = rows[i].querySelector('td:nth-child(5)').innerHTML;
+
+                if ((rowStatus === selectedStatus || selectedStatus === 'ALL') && (rowCategory === selectedCategory || selectedCategory === 'ALL')) {
                     rows[i].style.display = 'table-row';
-                }
-            } else {
-                for (var i = 1; i < rows.length; i++) {
-                    var rowStatus = rows[i].querySelector('td:nth-child(4)').innerHTML;
-                    
-                    if (rowStatus !== selectedStatus) {
-                        rows[i].style.display = 'none';
-                    } else {
-                        rows[i].style.display = 'table-row';
-                    }
+                } else {
+                    rows[i].style.display = 'none';
                 }
             }
+            
         }
 
         function postForm(model, id){
-            document.getElementById('id').value = id;
-            document.getElementById('model').value = model;
-            form = document.getElementById("postForm");
-            form.submit();
+            var actionText = "";
+            switch(model) {
+                case 0:
+                    actionText = "delete this item ? ";
+                    break;
+                case 1:
+                    actionText = "delete this category ? it also delete all item fllow";
+                    break;
+                case 2:
+                    actionText = "finish this item ? it and all children (if have) will be COMPLETE";
+                    break;
+                }
+            var confirmationMessage = "Are you sure you want to " + actionText;
+
+            if (window.confirm(confirmationMessage)) {
+                document.getElementById('id').value = id;
+                document.getElementById('model').value = model;
+                form = document.getElementById("postForm");
+                form.submit();
+            } 
         }
     </script>
 </body>

--- a/views/infoItem.php
+++ b/views/infoItem.php
@@ -21,7 +21,7 @@
 
         <div class="tab">
             <button class="tablinks active" onclick="openTab(event, 'tab1')">Item's Infomation</button>
-            <button class="tablinks" onclick="openTab(event, 'tab2')">Childs Item</button>
+            <button class="tablinks" onclick="openTab(event, 'tab2')">Children Item</button>
             <button class="tablinks" onclick="openTab(event, 'tab3')">Parent Item</button>
         </div>
 
@@ -36,7 +36,7 @@
                 <br>
 
                 <label for="category">Category</label>
-                <select name="category" id="category" required>
+                <select name="category" id="category" onchange="checkCategoryChange(<?php echo $mainItem->getCategoryId()?>)" required>
                     <?php
                         foreach ($allCategories as $category) {
                             $categoryId = $category->getId();
@@ -46,6 +46,7 @@
                         }
                     ?>
                 </select>
+                <input style='display: none' id="baseCategory" value="<?php echo $categories[$mainItem->getCategoryId()]?>">
                 <br>
 
                 <label for="status">Status</label>
@@ -79,37 +80,50 @@
 
         <div id="tab2" class="tabcontent">
             <table class="task-table" id="table1">
-                <tr>
-                    <th>Title</th>
-                    <th>Update Date</th>
-                    <th>Finish Date</th>
-                    <th>Status :
-                        <select onchange="filterTableByStatus('table2')">
-                            <option value='ALL'>ALL</option>
-                            <option value='TODO'>TODO</option>
-                            <option value='INPROGRESS'>INPROGRESS</option>
-                            <option value='COMPLETE'>COMPLETE</option>
-                            <option value='POSTPONE'>POSTPONE</option>
-                        </select>
-                    </th>
-                    <th>Action</th>
-                </tr>
-                <?php
-                        $html = '';
-                        foreach ($subItems as $item) {
-                            $html .= '<tr>';
-                            $html .= '<td>' . $item->getTitle() . '</td>';
-                            $html .= '<td>' . $item->getUpdateTime() . '</td>';
-                            $html .= '<td>' . $item->getFinishTime() . '</td>';
-                            $html .= '<td>' . STATUS[$item->getStatus()] . '</td>';
-                            $html .= '<td>';
-                            $html .= '<a class="delete-btn" onclick="postForm(0, ' . $item->getId() . ')">Delete</a>';
-                            $html .= '<a class="edit-btn" href="' . str_replace('{id}', $item->getId(), $routes->get('loadInfoItem')->getPath()) . '">Edit</a>';
-                            $html .= '</td>';
-                            $html .= '</tr>';
-                        }
-                    echo $html;
-                ?>
+            <tr>
+                        <th>Title</th>
+                        <th>Update Date</th>
+                        <th>Finish Date</th>
+                        <th>Status : 
+                            <select name='status' onchange="filterTable('table1')">
+                                <option value='ALL'>ALL</option>
+                                <option value='TODO'>TODO</option>
+                                <option value='INPROGRESS'>INPROGRESS</option>
+                                <option value='COMPLETE'>COMPLETE</option>
+                                <option value='POSTPONE'>POSTPONE</option>
+                            </select>
+                        </th>
+                        <th>Category : 
+                            <select name='category' onchange="filterTable('table1')">
+                                <option value='ALL'>ALL</option>
+                                <?php
+                                    foreach ($allCategories as $category) {
+                                        $categoryContent = $category->getContent();
+                                        echo '<option value="' . htmlspecialchars($categoryContent) . '" ' . '>' . htmlspecialchars($categoryContent) . '</option>';
+                                    }
+                                ?>
+                            </select>
+                        </th>
+                        <th>Action</th>
+                    </tr>
+                    <?php
+                            $html = '';
+                            foreach ($subItems as $item) {
+                                $html .= '<tr>';
+                                $html .= '<td>' . $item->getTitle() . '</td>';
+                                $html .= '<td>' . $item->getUpdateTime() . '</td>';
+                                $html .= '<td>' . $item->getFinishTime() . '</td>';
+                                $html .= '<td>' . STATUS[$item->getStatus()] . '</td>';
+                                $html .= '<td>' . $categories[$item->getCategoryId()] . '</td>';
+                                $html .= '<td>';
+                                $html .= '<a class="delete-btn" onclick="postForm(0, ' . $item->getId() . ')">Delete</a>';
+                                $html .= '<a class="edit-btn" href="' . str_replace('{id}', $item->getId(), $routes->get('loadInfoItem')->getPath()) . '">Edit</a>';
+                                $html .= '<a class="finish-btn" onclick="postForm(2, ' . $item->getId() . ')">Finish</a>';
+                                $html .= '</td>';
+                                $html .= '</tr>';
+                            }
+                        echo $html;
+                    ?>
             </table>
         </div>
 
@@ -127,13 +141,24 @@
                     echo '<th>Update Date</th>';
                     echo '<th>Finish Date</th>';
                     echo '<th>Status :
-                            <select onchange="filterTableByStatus(\'table2\')">
+                            <select name="status" onchange="filterTable(\'table2\')">
                                 <option value=\'ALL\'>ALL</option>
                                 <option value=\'TODO\'>TODO</option>
                                 <option value=\'INPROGRESS\'>INPROGRESS</option>
                                 <option value=\'COMPLETE\'>COMPLETE</option>
                                 <option value=\'POSTPONE\'>POSTPONE</option>
                             </select>
+                        </th>';
+                    echo '<th>Category : 
+                            <select name="category" onchange="filterTable(\'table2\')">
+                                <option value=\'ALL\'>ALL</option>';
+                                
+                                    foreach ($allCategories as $category) {
+                                        $categoryContent = $category->getContent();
+                                        echo '<option value="' . htmlspecialchars($categoryContent) . '" ' . '>' . htmlspecialchars($categoryContent) . '</option>';
+                                    }
+                                
+                    echo '</select>
                         </th>';
                     echo '<th>Action</th>';
                     echo '</tr>';
@@ -144,9 +169,11 @@
                         echo '<td>' . $item->getUpdateTime() . '</td>';
                         echo '<td>' . $item->getFinishTime() . '</td>';
                         echo '<td>' . STATUS[$item->getStatus()] . '</td>';
+                        echo '<td>' . $categories[$item->getCategoryId()] . '</td>';
                         echo '<td>';
                         echo '<a class="delete-btn" onclick="postForm(0, ' . $item->getId() . ')">Delete</a>';
                         echo '<a class="edit-btn" href="' . str_replace('{id}', $item->getId(), $routes->get('loadInfoItem')->getPath()) . '">Edit</a>';
+                        echo '<a class="finish-btn" onclick="postForm(2, ' . $item->getId() . ')">Finish</a>';
                         echo '</td>';
                         echo '</tr>';
                     }
@@ -174,36 +201,71 @@
             evt.currentTarget.className += " active";
         }
 
-        function filterTableByStatus(tableId) {
-            var statusFilter = document.querySelector('#' + tableId + ' select');
-            
+        function filterTable(tableId) {
+            var statusFilter = document.querySelector('#' + tableId + ' select[name="status"]');
             var selectedStatus = statusFilter.value;
-            
+
+            var categoryFilter = document.querySelector('#' + tableId + ' select[name="category"]');
+            var selectedCategory = categoryFilter.value;
+
             var rows = document.querySelectorAll('#' + tableId + ' tr');
             
-            if (selectedStatus === 'ALL') {
-                for (var i = 0; i < rows.length; i++) {
+            for (var i = 1; i < rows.length; i++) {
+                var rowStatus = rows[i].querySelector('td:nth-child(4)').innerHTML;
+                var rowCategory = rows[i].querySelector('td:nth-child(5)').innerHTML;
+
+                if ((rowStatus === selectedStatus || selectedStatus === 'ALL') && (rowCategory === selectedCategory || selectedCategory === 'ALL')) {
                     rows[i].style.display = 'table-row';
-                }
-            } else {
-                for (var i = 1; i < rows.length; i++) {
-                    var rowStatus = rows[i].querySelector('td:nth-child(4)').innerHTML;
-                    
-                    if (rowStatus !== selectedStatus) {
-                        rows[i].style.display = 'none';
-                    } else {
-                        rows[i].style.display = 'table-row';
-                    }
+                } else {
+                    rows[i].style.display = 'none';
                 }
             }
+            
         }
 
         function postForm(model, id){
-            document.getElementById('id').value = id;
-            document.getElementById('model').value = model;
-            form = document.getElementById("postForm");
-            form.submit();
+            var actionText = "";
+            switch(model) {
+                case 0:
+                    actionText = "delete this item ? ";
+                    break;
+                case 1:
+                    actionText = "delete this category ? it also delete all item fllow";
+                    break;
+                case 2:
+                    actionText = "finish this item ? it and all children (if have) will be COMPLETE";
+                    break;
+                }
+            var confirmationMessage = "Are you sure you want to " + actionText;
+
+            if (window.confirm(confirmationMessage)) {
+                document.getElementById('id').value = id;
+                document.getElementById('model').value = model;
+                form = document.getElementById("postForm");
+                form.submit();
+            } 
         }
+
+        function checkCategoryChange(categoryId) {
+            var selectedValue = document.getElementById("category").value;
+            var baseValue = document.getElementById("baseCategory").value;
+
+            if (selectedValue !== categoryId) {
+                alert("Your category is " + baseValue + ".\nIf you SAVE: this, all subItem and also parentItem's category will be change to");
+            }
+        }
+
+        document.addEventListener("DOMContentLoaded", function () {
+            var startDateInput = document.getElementById("finishTime");
+
+            var today = new Date().toISOString().split('T')[0];
+            var max = <?php if(count($parentItems) > 0) {echo '"' . $parentItems[0]->getFinishTime() . '";';} else {echo 'null';}?>
+
+            startDateInput.setAttribute("min", today);
+            if(max !== 'null') {
+                startDateInput.setAttribute("max", max);
+            }
+        })
     </script>
 </body>
 </html>


### PR DESCRIPTION
**Ticket**
SIM-7
link: https://simple-php.atlassian.net/jira/software/projects/SIM/boards/1?selectedIssue=SIM-7

**Description**
1. Add one column: category to item table => can filter by category 

2. Improve logic between main item and sub items:

* Update status of main item => update all sub item's status

* Update all sub item’s status => update main item’s status

* Change category of main item => change all sub item 's category

* Change category of sub item => show confirm pop-up => if user click “Accept“ => change main item and other sub items 's category

3 Add one action to action column => Delete, Edit → Delete, Edit, Finish:

* When click finish button => update status of that item to finish (follow logic 2.)

**Videos/Screenshots**
* Limit date follow parent
![sim-7-limit-finishTime-by-parent](https://github.com/Nate-go/SimplePHP/assets/140036945/49f13460-7c9e-4d5c-904e-1af5f03a6d21)
* List item follow category
![sim-7-listItem-follow-category](https://github.com/Nate-go/SimplePHP/assets/140036945/05079d03-0a7e-4de7-b1d1-74ed17513616)
* Quick finish
![sim-7-quick-finish](https://github.com/Nate-go/SimplePHP/assets/140036945/397da08b-7b1d-41c5-b7a9-7b02455f5f1a)
* Unset category of child
![sim-7-unset-category-of-child](https://github.com/Nate-go/SimplePHP/assets/140036945/485e3226-3bc5-471a-ae27-0fff403c152f)
* Confirm before delete
![sim-7-asking-before-delete](https://github.com/Nate-go/SimplePHP/assets/140036945/8cdd6842-28aa-49dc-9cc3-b5574be76523)
* Confirm before finish
![sim-7-asking-bofore-finish](https://github.com/Nate-go/SimplePHP/assets/140036945/a6d68136-7fe1-42c6-b3ab-8aeda7b89578)
